### PR TITLE
added feature to cleanup older plex builds

### DIFF
--- a/assets/scripts/startup.sh
+++ b/assets/scripts/startup.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+# directory to store plex build downloads
 DOWNLOAD_DIR="/plex/downloads"
+
+# number of previous releases to keep in download directory
+PLEX_NUM=2
 
 # ensure plex server version env variable is present
 if [ "${PLEX_SERVER_VERSION}" == "" ]; then
@@ -23,6 +27,18 @@ fi
 
 # install latest plex media server
 dpkg -i ${DOWNLOAD_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb
+
+# clean up old builds
+i=0
+for BUILD in $(find ${DOWNLOAD_DIR} -name plexmediaserver*.deb -print0| xargs -0 ls -t); do
+  # is counter greater than number of builds to keep?
+  if [ $i -gt ${PLEX_NUM} ]; then
+    rm -f $BUILD
+  fi
+  # increase counter
+  let i+=1
+done
+
 
 # update default config file
 mv -f /tmp/default-plexmediaserver /etc/default/plexmediaserver

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ function start_container() {
               --volume=${LOCAL_MOVIE_DIR}:/movies:ro           \
               --volume=${LOCAL_TV_DIR}:/tv:ro                  \
               --volume=${LOCAL_PLEX_DIR}:/plex:rw              \
-              -d ${IMAGE_NAME}:latest > /dev/null
+              --detach ${IMAGE_NAME}:latest > /dev/null
 }
 
 # check if docker container with same name is already running.


### PR DESCRIPTION
this way we don't use up disk space with too many old builds.

plus, for consistency, i changed the `-d` flat to `--detach`. now all the `docker run` flags are long form :+1: 
