### PR TITLE
runas plex user with modified uid/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,10 @@ MAINTAINER chris turra <cturra@gmail.com>
 
 ENV DEBIAN_FRONTEND     noninteractive
 
-# install/config supervisord and grab wget
+# install/config supervisord and grab curl and jq
 # so we can download plex
 RUN apt-get -qq update             \
  && apt-get -yf install supervisor \
-                        wget       \
                         curl       \
                         jq         \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ENV DEBIAN_FRONTEND     noninteractive
 RUN apt-get -qq update             \
  && apt-get -yf install supervisor \
                         wget       \
+                        curl       \
+                        jq         \
  && rm -rf /var/lib/apt/lists/*
 
 # copy config files into container

--- a/assets/configs/supervisor/plex.conf
+++ b/assets/configs/supervisor/plex.conf
@@ -3,7 +3,8 @@ nodaemon=true
 
 [program:plex]
 command=/usr/sbin/start_pms
-environment=HOME="/plex",PWD="/plex",LOGNAME="root",USER="root",TERM=xterm
+environment=HOME="/plex",PWD="/plex",TERM=xterm
+user=plex
 stdout_logfile=/plex/logs/supervisor/%(program_name)s.log
 stderr_logfile=/plex/logs/supervisor/%(program_name)s.log
 autostart=true

--- a/assets/scripts/startup.sh
+++ b/assets/scripts/startup.sh
@@ -2,6 +2,10 @@
 
 # directory to store plex build downloads
 DOWNLOAD_DIR="/plex/downloads"
+# plex library
+PLEX_LIBRARY="/plex/Library"
+# supervisord logs
+SUPERVISORD_LOGS="/plex/logs/supervisor"
 
 # number of previous releases to keep in download directory
 PLEX_NUM=2
@@ -21,6 +25,7 @@ fi
 # if not, download it
 if [ ! -f "${DOWNLOAD_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb" ]; then
   # download plex media server
+  echo "downloading plexmediaserver_${PLEX_SERVER_VERSION}"
   wget -O ${DOWNLOAD_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb \
        -q https://downloads.plex.tv/plex-media-server/${PLEX_SERVER_VERSION}/plexmediaserver_${PLEX_SERVER_VERSION}_${PLEX_SERVER_ARCH}.deb
 fi
@@ -40,7 +45,35 @@ for BUILD in $(find ${DOWNLOAD_DIR} -name plexmediaserver*.deb -print0| xargs -0
 done
 
 # update default config file
-mv -f /tmp/default-plexmediaserver /etc/default/plexmediaserver
+if [ -f /tmp/default-plexmediaserver ]; then
+  echo "copying config to /etc/default/plexmediaserver"
+  mv -f /tmp/default-plexmediaserver /etc/default/plexmediaserver
+fi
+
+# force update plex user to match NFS user if defined
+if [[ (! -z ${PLEX_UID}) && (! -z ${PLEX_GID}) ]]; then
+  echo "setting up PLEX UID:${PLEX_UID} and GID:${PLEX_GID}"
+  groupmod -g ${PLEX_GID} plex
+  usermod -u ${PLEX_UID} plex
+fi
+
+# preseed plex library and ensure permissions are setup properly
+if [ ! -d ${PLEX_LIBRARY} ]; then
+  echo "setting up PLEX Library"
+  mkdir -p -m 2775 ${PLEX_LIBRARY}
+  chown -R plex:plex ${PLEX_LIBRARY}
+else
+  # ensure permissions are correct if we exist
+  chown -R plex:plex ${PLEX_LIBRARY}
+  chmod 2775 ${PLEX_LIBRARY}
+fi
+
+# ensure supervisor logfile is present
+if [ ! -f ${SUPERVISORD_LOGS}/plex.log ]; then
+  echo "setting up ${SUPERVISORD_LOGS}"
+  mkdir -p ${SUPERVISORD_LOGS}
+  touch ${SUPERVISORD_LOGS}/plex.log
+fi
 
 # start supervisor
 /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,11 @@
 source vars
 
 # generate a build tag based on plex server version
-BUILD_TAG=$(echo ${PLEX_SERVER_VERSION}| awk -F'.' '{print $1"."$2"."$3"."$4}')
+if [[ "${PLEX_SERVER_VERSION}" == "public" || "${PLEX_SERVER_VERSION}" == "plexpass" ]] ; then
+  BUILD_TAG=${PLEX_SERVER_VERSION}
+else
+  BUILD_TAG= $(echo ${PLEX_SERVER_VERSION}| awk -F'.' '{print $1"."$2"."$3"."$4}')
+fi
 
 DOCKER=$(which docker)
 

--- a/run.sh
+++ b/run.sh
@@ -12,14 +12,21 @@ function check_container() {
 
 # function to start new docker container
 function start_container() {
+  # if defining plex uid and gid, pass it to docker
+  # otherwise, nothing to see here
+  USER_OPTS=""
+  if [[ (! -z ${PLEX_UID}) && (! -z ${PLEX_GID}) ]]; then
+    USER_OPTS="--env=PLEX_UID=${PLEX_UID} --env=PLEX_GID=${PLEX_GID}"
+  fi
+
   $DOCKER run --name=${CONTAINER_NAME} ${DOCKER_OPTS}          \
               --restart=always                                 \
               --net=host                                       \
               --env=PLEX_SERVER_VERSION=${PLEX_SERVER_VERSION} \
               --env=PLEX_SERVER_ARCH=${PLEX_SERVER_ARCH}       \
-              --volume=${LOCAL_MOVIE_DIR}:/movies:ro           \
-              --volume=${LOCAL_TV_DIR}:/tv:ro                  \
-              --volume=${LOCAL_PLEX_DIR}:/plex:rw              \
+              --volume=${LOCAL_MEDIA_DIR}:/mediabox:ro         \
+              --volume=${LOCAL_DATA_DIR}:/plex:rw              \
+              ${USER_OPTS}                                     \
               --detach ${IMAGE_NAME}:latest > /dev/null
 }
 

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@
 source vars
 
 DOCKER=$(which docker)
+CURL=$(which curl)
 
 # function to check if container is running
 function check_container() {
@@ -19,12 +20,17 @@ function start_container() {
     USER_OPTS="--env=PLEX_UID=${PLEX_UID} --env=PLEX_GID=${PLEX_GID}"
   fi
 
+  # what version should we pass to the container?
+  if [ ${PLEX_SERVER_VERSION} == "latest" ]; then
+    PLEX_SERVER_VERSION=$(${CURL} -s https://plex.tv/downloads | grep ".deb" | grep -m 1 ${PLEX_SERVER_ARCH} | sed "s|.*plex-media-server/\(.*\)/plexmediaserver.*|\1|")
+  fi
+
   $DOCKER run --name=${CONTAINER_NAME} ${DOCKER_OPTS}          \
               --restart=always                                 \
               --net=host                                       \
               --env=PLEX_SERVER_VERSION=${PLEX_SERVER_VERSION} \
               --env=PLEX_SERVER_ARCH=${PLEX_SERVER_ARCH}       \
-              --volume=${LOCAL_MEDIA_DIR}:/mediabox:ro         \
+              --volume=${LOCAL_MEDIA_DIR}:/media:ro            \
               --volume=${LOCAL_DATA_DIR}:/plex:rw              \
               ${USER_OPTS}                                     \
               --detach ${IMAGE_NAME}:latest > /dev/null

--- a/vars
+++ b/vars
@@ -8,13 +8,18 @@ IMAGE_NAME="cturra/plex"
 CONTAINER_NAME="plex"
 
 # plex media server build and architecture you want to run.
-# example: 0.9.15.2.1663-7efd046
-#          amd64
-PLEX_SERVER_VERSION=0.9.16.0.1754-23623fb
+# you can define a specific build or latest
+# example:
+# PLEX_SERVER_VERSION=0.9.15.2.1663-7efd046
+# PLEX_SERVER_VERSION=latest
+#
+# PLEX_SERVER_ARCH=amd64
+
+PLEX_SERVER_VERSION=latest
 PLEX_SERVER_ARCH=amd64
 
 # directories on the local host content will be mounted.
-LOCAL_MEDIA_DIR="/mediabox"
+LOCAL_MEDIA_DIR="/media"
 LOCAL_DATA_DIR="/data/plex"
 
 # force plex uid/gid for NFS

--- a/vars
+++ b/vars
@@ -7,16 +7,25 @@
 IMAGE_NAME="cturra/plex"
 CONTAINER_NAME="plex"
 
-# plex media server build and architecture you want to run.
-# you can define a specific build or latest
+# plex media server architecture you want to run.
+# PLEX_SERVER_ARCH=amd64
+PLEX_SERVER_ARCH=amd64
+
+# plex media server build or release channel you want to install
+# you can define a specific build OR
+# public to fetch the latest for public release OR
+# plexpass to fetch the latest plexpass release
+#
 # example:
 # PLEX_SERVER_VERSION=0.9.15.2.1663-7efd046
-# PLEX_SERVER_VERSION=latest
-#
-# PLEX_SERVER_ARCH=amd64
+# PLEX_SERVER_VERSION=public
+# PLEX_SERVER_VERSION=plexpass
 
-PLEX_SERVER_VERSION=latest
-PLEX_SERVER_ARCH=amd64
+PLEX_SERVER_VERSION=public
+
+# plexpass will require a valid plexpass account
+#PLEXPASS_USER="username"
+#PLEXPASS_PASS="password"
 
 # directories on the local host content will be mounted.
 LOCAL_MEDIA_DIR="/media"

--- a/vars
+++ b/vars
@@ -10,13 +10,16 @@ CONTAINER_NAME="plex"
 # plex media server build and architecture you want to run.
 # example: 0.9.15.2.1663-7efd046
 #          amd64
-PLEX_SERVER_VERSION=0.9.15.6.1714-7be11e1
+PLEX_SERVER_VERSION=0.9.16.0.1754-23623fb
 PLEX_SERVER_ARCH=amd64
 
 # directories on the local host content will be mounted.
-LOCAL_MOVIE_DIR="/media/movies"
-LOCAL_TV_DIR="/media/tv"
-LOCAL_PLEX_DIR="/data/plex"
+LOCAL_MEDIA_DIR="/mediabox"
+LOCAL_DATA_DIR="/data/plex"
+
+# force plex uid/gid for NFS
+#PLEX_UID=10003
+#PLEX_GID=10000
 
 # any additional docker run options you may want.
 # example: --cpuset-cpus="0-6"


### PR DESCRIPTION
some peoples old infra requires a valid user to read media.  if defined within vars, pass them along to startup.sh who will ensure container is running as plex with valid uid/gid for NFS access.

also ensure plex library and supervisord paths exist, this is required for new install

oh ya, fetch latest plex every ./run
- if plexpass + valid username / pass, fetch latest plexpass release
- if public, grab latest public release
- specific build? fetch specific build!
