### PR TITLE
updating installer/log handling

### DIFF
--- a/assets/configs/supervisor/plex.conf
+++ b/assets/configs/supervisor/plex.conf
@@ -5,7 +5,8 @@ nodaemon=true
 command=/usr/sbin/start_pms
 environment=HOME="/plex",PWD="/plex",TERM=xterm
 user=plex
-stdout_logfile=/plex/logs/supervisor/%(program_name)s.log
-stderr_logfile=/plex/logs/supervisor/%(program_name)s.log
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
 autostart=true
 autorestart=true


### PR DESCRIPTION
updated how the dpkg check is done to ensure we're not returning errors during startup. also, changed the download directory name to installers, since that's a more accurate description.

logging is no longer done to a file, but rather to stdout. this way the docker daemon log driver can be used directly. stderr is also directed to stdout so we don't lose it.
