### PR TITLE
MAINTAINER will soon become deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER chris turra <cturra@gmail.com>
-
-ENV DEBIAN_FRONTEND     noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 # install/config supervisord and grab curl and jq
 # so we can download plex


### PR DESCRIPTION
starting in docker-engine 1.13.0 the `MAINTAINER` command in the Dockerfile will beging the process of being deprecated. since we're already tracking maintainers in the CONTRIBUTORS file, there is no need for this command/layer anyway.

docker project ref: https://github.com/docker/docker/pull/25466