### PR TITLE
switching from bridge network from host

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -35,13 +35,22 @@ function start_container() {
 
   $DOCKER run ${DOCKER_OPTS}                                   \
               --name=${CONTAINER_NAME}                         \
-              --restart=always                                 \
-              --net=host                                       \
+              --hostname=${CONTAINER_HOST_NAME}                \
+              --detach=true                                    \
+              --restart=on-failure:2                           \
+              --publish=3005:3005/tcp                          \
+              --publish=8324:8324/tcp                          \
+              --publish=32400:32400/tcp                        \
+              --publish=32469:32469/tcp                        \
+              --publish=1900:1900/udp                          \
+              --publish=32410:32410/udp                        \
+              --publish=32412:32412/udp                        \
+              --publish=32413:32413/udp                        \
+              --publish=32414:32414/udp                        \
               --env=PLEX_SERVER_VERSION=${PLEX_SERVER_VERSION} \
               --env=PLEX_SERVER_ARCH=${PLEX_SERVER_ARCH}       \
               --volume=${LOCAL_MEDIA_DIR}:/media:ro            \
               --volume=${LOCAL_DATA_DIR}:/plex:rw              \
-              --detach=true                                    \
               ${USER_OPTS}                                     \
               ${PLEXPASS_OPTS}                                 \
               ${IMAGE_NAME}:latest > /dev/null

--- a/vars
+++ b/vars
@@ -7,6 +7,10 @@
 IMAGE_NAME="cturra/plex"
 CONTAINER_NAME="plex"
 
+# name your plex media server something other than the random
+# container id
+CONTAINER_HOST_NAME="plex"
+
 # plex media server architecture you want to run.
 # supported: amd64 & i386
 PLEX_SERVER_ARCH=amd64


### PR DESCRIPTION
we now publish only the tcp/udp ports needed for plex instead of using `net=host`. additionally, there is a new vars flag for the `CONTAINER_HOST_NAME` so you can pass in a custom hostname instead
of getting a random container id (shows in the plex web console).

also changed the restart policy from `always` to `on-failure:2`. this will ensure that if there is indeed an error when starting pid1, it will only try to start the container 2 times before stopping (instead of forever).