### PR TITLE
Downloader update

### DIFF
--- a/assets/scripts/startup.sh
+++ b/assets/scripts/startup.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
 
-# plex.tv base download location (url)
-PUBLIC_DOWNLOAD_URL="https://plex.tv/api/downloads/1.json"
-PLEXPASS_DOWNLOAD_URL="https://plex.tv/api/downloads/5.json?channel=plexpass"
+# plex.tv base download locations (url)
+PLEX_DOWNLOAD_BASE_URL="https://plex.tv/api/downloads/"
+PUBLIC_DOWNLOAD_URL="${PLEX_DOWNLOAD_BASE_URL}/1.json"
+PLEXPASS_DOWNLOAD_URL="${PLEX_DOWNLOAD_BASE_URL}/5.json?channel=plexpass"
+
 # directory to store plex build downloads
 INSTALLER_DIR="/plex/installers"
+
 # plex library
 PLEX_LIBRARY="/plex/Library"
 
 # number of previous releases to keep in download directory
 PLEX_NUM=2
 
+# curl arguments
 CURL_OPTS="-s -H X-Plex-Client-Identifier:docker-plexmediaserver -H X-Plex-Product:docker-plexmediaserver -H X-Plex-Version:0.0.1"
 
+# binary packages
 CURL=$(which curl)
 JQ=$(which jq)
 DPKG=$(which dpkg)
+
 
 plex_public () {
   DISTRO="ubuntu"

--- a/assets/scripts/startup.sh
+++ b/assets/scripts/startup.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # plex.tv base download location (url)
-DOWNLOAD_URL="https://plex.tv/api/downloads/1.json"
+PUBLIC_DOWNLOAD_URL="https://plex.tv/api/downloads/1.json"
+PLEXPASS_DOWNLOAD_URL="https://plex.tv/api/downloads/5.json?channel=plexpass"
 # directory to store plex build downloads
 INSTALLER_DIR="/plex/installers"
 # plex library
@@ -10,67 +11,80 @@ PLEX_LIBRARY="/plex/Library"
 # number of previous releases to keep in download directory
 PLEX_NUM=2
 
+CURL_OPTS="-s -H X-Plex-Client-Identifier:docker-plexmediaserver -H X-Plex-Product:docker-plexmediaserver -H X-Plex-Version:0.0.1"
+
 CURL=$(which curl)
 JQ=$(which jq)
 DPKG=$(which dpkg)
 
 plex_public () {
-  PLEX_SERVER_VERSION=$($CURL -s ${DOWNLOAD_URL}| grep ".deb"| grep -m 1 ${PLEX_SERVER_ARCH}| sed "s|.*plex-media-server/\(.*\)/plexmediaserver.*|\1|")
+  DISTRO="ubuntu"
+  BUILD="linux-ubuntu-x86_64"
+  URL=$(get_plex_url ${DISTRO} ${BUILD} ${PUBLIC_DOWNLOAD_URL})
+  download_plex ${URL}
 }
 
 plex_plexpass () {
+  DISTRO="debian"
+  BUILD="linux-x86_64"
+
   # create POST payload
   AUTH="user%5Blogin%5D=${PLEXPASS_USER}&user%5Bpassword%5D=${PLEXPASS_PASS}"
   # auth against plex.tv and pull down X-Plex-Token
-  CURL_OPTS="-s -H X-Plex-Client-Identifier:docker-plexmediaserver -H X-Plex-Product:docker-plexmediaserver -H X-Plex-Version:0.0.1"
   TOKEN=$($CURL ${CURL_OPTS} --data "${AUTH}" 'https://plex.tv/users/sign_in.json'| $JQ -r .user.authentication_token)
 
   if [ ${TOKEN} == "null" ] || [ -z ${TOKEN} ]; then
     echo "[INFO] Unable to authenticate, falling back to public release"
     plex_public
   else
-    # grab downloads now
-    PLEX_SERVER_VERSION=$($CURL ${CURL_OPTS} -H "X-Plex-Token:${TOKEN}" "${DOWNLOAD_URL}?channel=plexpass"| grep ".deb"| grep -m 1 ${PLEX_SERVER_ARCH}| sed "s|.*plex-media-server/\(.*\)/plexmediaserver.*|\1|")
+    CURL_OPTS="${CURL_OPTS} -H X-Plex-Token:${TOKEN}"
+    URL=$(get_plex_url ${DISTRO} ${BUILD} ${PLEXPASS_DOWNLOAD_URL})
+    download_plex ${URL}
+  fi
+}
+
+get_plex_url () {
+  DISTRO=${1}
+  BUILD=${2}
+  DOWNLOAD_URL=${3}
+  URL=$($CURL ${CURL_OPTS} "${DOWNLOAD_URL}"| ${JQ} -r --arg build ${BUILD} --arg distro "${DISTRO}" '.computer.Linux.releases[] | select(.build == $build and .distro == $distro) .url')
+  echo ${URL}
+}
+
+download_plex () {
+  URL=$1
+  # check if /plex directory is present
+  if [ ! -d "${INSTALLER_DIR}" ]; then
+    echo "[INFO] Creating ${INSTALLER_DIR}"
+    mkdir ${INSTALLER_DIR}
+  fi
+
+  # parse PLEX_SERVER_VERSION from URL
+  PLEX_SERVER_VERSION=${URL%_*}
+  PLEX_SERVER_VERSION=${PLEX_SERVER_VERSION#*_}
+
+  # check if plex install file already exists on disk
+  # if not, download it
+  if [ ! -f "${INSTALLER_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb" ]; then
+    # download plex media server
+    echo "[INFO] Downloading plexmediaserver_${PLEX_SERVER_VERSION}"
+    $CURL -s --retry 2 -o ${INSTALLER_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb ${URL}
+    if [ $? -ne 0 ]; then
+      echo "[ERROR] Unable to download ${URL}"
+      exit 1
+    fi
   fi
 }
 
 # check which plex server version to install
 case "${PLEX_SERVER_VERSION}" in
-  "public")
-    plex_public
-    ;;
   "plexpass")
     plex_plexpass
     ;;
   *)
-    echo "[INFO] Using ${PLEX_SERVER_VERSION}"
+    plex_public
     ;;
 esac
-
-# ensure plex server version env variable is present
-if [ "${PLEX_SERVER_VERSION}" == "" ] || [ "${PLEX_SERVER_ARCH}" == "" ]; then
-  echo "[ERROR] No Plex server version ($PLEX_SERVER_VERSION) or architecture ($PLEX_SERVER_ARCH) are defined."
-  exit 1
-fi
-
-# check if /plex directory is present
-if [ ! -d "${INSTALLER_DIR}" ]; then
-  echo "[INFO] Creating ${INSTALLER_DIR}"
-  mkdir ${INSTALLER_DIR}
-fi
-
-# check if plex install file already exists on disk
-# if not, download it
-if [ ! -f "${INSTALLER_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb" ]; then
-  # download plex media server
-  echo "[INFO] Downloading plexmediaserver_${PLEX_SERVER_VERSION}"
-  $CURL -s --retry 2 -o ${INSTALLER_DIR}/plexmediaserver_${PLEX_SERVER_VERSION}.deb \
-        https://downloads.plex.tv/plex-media-server/${PLEX_SERVER_VERSION}/plexmediaserver_${PLEX_SERVER_VERSION}_${PLEX_SERVER_ARCH}.deb
-  if [ $? -ne 0 ]; then
-    echo "[ERROR] Unable to download https://downloads.plex.tv/plex-media-server/${PLEX_SERVER_VERSION}/plexmediaserver_${PLEX_SERVER_VERSION}_${PLEX_SERVER_ARCH}.deb"
-    exit 1
-  fi
-fi
 
 # check if plex already installed
 if [[ "$($DPKG --status plexmediaserver 2>/dev/null| grep Status\:)" == *"ok installed" ]]; then

--- a/run.sh
+++ b/run.sh
@@ -28,11 +28,6 @@ function start_container() {
     PLEXPASS_OPTS="--env=PLEXPASS_USER=${PLEXPASS_USER} --env=PLEXPASS_PASS=${PLEXPASS_PASS}"
   fi
 
-  # what version should we pass to the container?
-  if [ ${PLEX_SERVER_VERSION} == "latest" ]; then
-    PLEX_SERVER_VERSION=$(${CURL} -s https://plex.tv/downloads| grep ".deb"| grep -m 1 ${PLEX_SERVER_ARCH}| sed "s|.*plex-media-server/\(.*\)/plexmediaserver.*|\1|")
-  fi
-
   $DOCKER run ${DOCKER_OPTS}                                   \
               --name=${CONTAINER_NAME}                         \
               --hostname=${CONTAINER_HOST_NAME}                \
@@ -48,7 +43,6 @@ function start_container() {
               --publish=32413:32413/udp                        \
               --publish=32414:32414/udp                        \
               --env=PLEX_SERVER_VERSION=${PLEX_SERVER_VERSION} \
-              --env=PLEX_SERVER_ARCH=${PLEX_SERVER_ARCH}       \
               --volume=${LOCAL_MEDIA_DIR}:/media:ro            \
               --volume=${LOCAL_DATA_DIR}:/plex:rw              \
               ${USER_OPTS}                                     \

--- a/vars
+++ b/vars
@@ -11,7 +11,7 @@ CONTAINER_NAME="plex"
 # container id
 CONTAINER_HOST_NAME="plex"
 
-# plex media server build or release channel you want to install
+# plex media server release channel you want to install
 # public to fetch the latest for public release OR
 # plexpass to fetch the latest plexpass release
 #

--- a/vars
+++ b/vars
@@ -11,17 +11,11 @@ CONTAINER_NAME="plex"
 # container id
 CONTAINER_HOST_NAME="plex"
 
-# plex media server architecture you want to run.
-# supported: amd64 & i386
-PLEX_SERVER_ARCH=amd64
-
 # plex media server build or release channel you want to install
-# you can define a specific build OR
 # public to fetch the latest for public release OR
 # plexpass to fetch the latest plexpass release
 #
 # examples:
-#  PLEX_SERVER_VERSION=0.9.15.2.1663-7efd046
 #  PLEX_SERVER_VERSION=public
 #  PLEX_SERVER_VERSION=plexpass
 

--- a/vars
+++ b/vars
@@ -11,9 +11,9 @@ CONTAINER_NAME="plex"
 # container id
 CONTAINER_HOST_NAME="plex"
 
-# plex media server release channel you want to install
-# public to fetch the latest for public release OR
-# plexpass to fetch the latest plexpass release
+# plex media server release channel you want to install:
+#  - public:   to fetch the latest for public release OR
+#  - plexpass: to fetch the latest plexpass (beta) release
 #
 # examples:
 #  PLEX_SERVER_VERSION=public


### PR DESCRIPTION
refactor download components

plexpass manifest has moved behind a different URL and the json payload has also changed.

fix for issue: https://github.com/cturra/docker-plexmediaserver/issues/17

REMOVED:
- support for build pinning.  as this build could be behind either the new plexpass url or public, easier to remove
- support for i386.  all builds are pinning to amd64