### PR TITLE
adding HEALTHCHECK to tell docker how to test container health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,21 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # install/config supervisord and grab curl and jq
 # so we can download plex
-RUN apt-get -qq update             \
- && apt-get -yf install supervisor \
-                        curl       \
-                        jq         \
+RUN apt-get -q update             \
+ && apt-get -y install supervisor \
+                        curl      \
+                        jq        \
  && rm -rf /var/lib/apt/lists/*
 
 # copy config files into container
 COPY assets/configs/supervisor/plex.conf         /etc/supervisor/conf.d/
 COPY assets/configs/plex/default-plexmediaserver /tmp/
 
-# install startup script
-COPY assets/scripts/startup.sh /opt/startup.sh
+# install startup & healthcheck scripts
+COPY assets/scripts/* /opt/
+
+# let docker know how to test container health
+HEALTHCHECK --interval=5s --timeout=2s --retries=20 CMD /opt/healthcheck.sh || exit 1
 
 # kick off startup script
 ENTRYPOINT [ "/opt/startup.sh" ]

--- a/assets/scripts/healthcheck.sh
+++ b/assets/scripts/healthcheck.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+CURL=$(which curl)
+
+$CURL --connect-timeout 15 \
+      --silent             \
+      --show-error         \
+      --fail               \
+      "http://localhost:32400/identity" >/dev/null


### PR DESCRIPTION
this instructs docker how to validate the health of the container.

=> https://docs.docker.com/engine/reference/builder/#healthcheck

example from my local environment:
```
$> docker ps --filter "name=plex"
CONTAINER ID        IMAGE                COMMAND             CREATED             STATUS                   PORTS                                                                                                                                                                                        NAMES
e365556821cc        cturra/plex:latest   "/opt/startup.sh"   5 minutes ago       Up 5 minutes (healthy)   0.0.0.0:3005->3005/tcp, 0.0.0.0:8324->8324/tcp, 0.0.0.0:1900->1900/udp, 0.0.0.0:32410->32410/udp, 0.0.0.0:32400->32400/tcp, 0.0.0.0:32412-32414->32412-32414/udp, 0.0.0.0:32469->32469/tcp   plex
```