### PR TITLE
updating to support plexmediaserver 1.18.5 install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 # install/config supervisord and grab curl and jq
 # so we can download plex
 RUN apt-get -q update             \
  && apt-get -y install supervisor \
-                        curl      \
-                        jq        \
+                       curl       \
+                       jq         \
  && rm -rf /var/lib/apt/lists/*
 
 # copy config files into container


### PR DESCRIPTION
with the release of `plexmediaserver_1.18.5.2260-056ab4be9` today, there is a new dpkg `preinst` script check that breaks with this container. it specifically looks for the following docker containers:
```
111   # Looks like Docker  (s6-svscan = Plex/Linuxserver.io;  tini = binhex)
112   if [ "$(cat /proc/1/comm)" = "s6-svscan" ] || [ "$(cat /proc/1/comm)" = "tini" ]; then
113     Output both "Docker detected. Preinstallation validation not required."
114     exit 0
115   fi
```

this is the error i was seeing during dpkg install:
```
[INFO] Installing Plex 1.18.5.2260-056ab4be9.
Selecting previously unselected package plexmediaserver.
(Reading database ... 6336 files and directories currently installed.)
Preparing to unpack .../plexmediaserver_1.18.5.2260-056ab4be9.deb ...
PlexMediaServer install: Pre-installation Validation.
PlexMediaServer install: ERROR:  Plex Media Server can only be installed on 'init' or 'systemd' based systems.
PlexMediaServer install:         Your system has startup.sh but minimally required files are missing.
dpkg: error processing archive /plex/installers/plexmediaserver_1.18.5.2260-056ab4be9.deb (--install):
 subprocess new pre-installation script returned error exit status 1
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Errors were encountered while processing:
 /plex/installers/plexmediaserver_1.18.5.2260-056ab4be9.deb
```

as a result, i've added a step to the startup script to "fake" `/proc/1/comm` to look like the official pms container.

it also appears as though the plexmediaserver no longer creates the plex user, so the startup also checks to see if the user is present and if not, creates.

there were a couple additional updates to stay up to date with plex end-points and container software versions.

 - [start script] updated download base from plex.tv/api/.. to plex.tv/pms/...
 - [start script] updated public distro from ubuntu to debian
 - [start script] updated public build from linux-ubuntu-x86_64 to linux-x86_64
 - [dockerfile] updated Docker image base from ubuntu 16.04 to 18.04
 - [dockerfile] updated `DEBIAN_FRONTEND` environment variable from `ENV` to `ARG` so it would not persist into future containers run off the image, since that is not the intention here.