### PR TITLE
deprecated use of start_pms

### DIFF
--- a/assets/configs/supervisor/plex.conf
+++ b/assets/configs/supervisor/plex.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:plex]
-command=/usr/sbin/start_pms
+command=/usr/lib/plexmediaserver/Plex\ Media\ Server
 environment=HOME="/plex",PWD="/plex",TERM=xterm
 user=plex
 redirect_stderr=true


### PR DESCRIPTION
in the most recent `1.19.1.2589` plex media server release, `start_pm`s is no longer present. this update moves to using the new runtime command within supervisor.